### PR TITLE
Vite ssr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ const options = {
   bucket: '<Your Bucket>'
 }
 
+const prod = process.env.NODE_ENV === 'production'
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: 'https://foo.com/', // must be URL
+  base: prod ? 'https://foo.com/' : '/', // must be URL when build
   plugins: [vue(), vitePluginTencentOss(options)]
 })
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -51,9 +51,11 @@ const options = {
   bucket: '<Your Bucket>'
 }
 
+const prod = process.env.NODE_ENV === 'production'
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: 'https://foo.com/', // 必须是 URL
+  base: prod ? 'https://foo.com/' : '/', // 打包时必须是 URL
   plugins: [vue(), vitePluginTencentOss(options)]
 })
 ```

--- a/index.js
+++ b/index.js
@@ -41,13 +41,23 @@ module.exports = function vitePluginTencentOss(options) {
         SecretId,
         SecretKey,
       })
+      const ssrClient = buildConfig.ssrManifest
+      const ssrServer = buildConfig.ssr
       const files = await glob.sync(
         outDirPath + '/**/*',
         {
           strict: true,
           nodir: true,
           dot: true,
-          ignore: options.ignore ? options.ignore : '**/*.html'
+          ignore:
+            // custom ignore
+            options.ignore ? options.ignore :
+            // ssr client ignore
+            ssrClient ? ['**/ssr-manifest.json', '**/*.html'] :
+            // ssr server ignore
+            ssrServer ? ['**'] :
+            // default ignore
+            '**/*.html'
         }
       )
       log('tencent oss upload start')


### PR DESCRIPTION
1. ssr 模式打包时，vite 标准模版，会走 2 个命令分别打包客户端、服务端
```
"build:client": "vite build --ssrManifest --outDir dist/client",
"build:server": "vite build --ssr src/entry-server.js --outDir dist/server",
```
其中服务端部分不需要上传，客户端部分 ssr-manifest.json 不需要上传。
根据以上参数，配置 ignore 进行排除

2. 更新 README，base 选项区分本地运行 development、打包 production 的配置